### PR TITLE
Correct tiny RegEx mistake in LdapWorker

### DIFF
--- a/bwreg-service/src/main/java/edu/kit/scc/webreg/service/reg/ldap/LdapWorker.java
+++ b/bwreg-service/src/main/java/edu/kit/scc/webreg/service/reg/ldap/LdapWorker.java
@@ -605,7 +605,7 @@ public class LdapWorker {
 			ldapGroupObjectclasses = "top posixGroup";
 		
 		if (sambaEnabled) {
-			if (!ldapGroupObjectclasses.matches("(?:\\s|.)*?\\bsambaGroupMapping\\b(?:\\s|.)"))
+			if (!ldapGroupObjectclasses.matches("(?:\\s|.)*?\\bsambaGroupMapping\\b(?:\\s|.)*"))
 				ldapGroupObjectclasses += " sambaGroupMapping";
                         
 			attrs = AttributesFactory.createAttributes("objectClass",


### PR DESCRIPTION
Apparently, I made a mistake while copy-pasting. Since `String.matches()` needs to match the _entire_ string, the `*` at the end is very important.