### PR TITLE
Account deactivation

### DIFF
--- a/bwreg-jpa/src/main/java/edu/kit/scc/webreg/dao/SamlUserDao.java
+++ b/bwreg-jpa/src/main/java/edu/kit/scc/webreg/dao/SamlUserDao.java
@@ -17,8 +17,6 @@ import edu.kit.scc.webreg.entity.SamlUserEntity;
 public interface SamlUserDao extends BaseDao<SamlUserEntity> {
 
 	List<SamlUserEntity> findUsersForPseudo(Long onHoldSince, int limit);
-	SamlUserEntity findByPersistentWithRoles(String spId, String idpId,
-			String persistentId);
 	SamlUserEntity findByEppn(String eppn);
 	SamlUserEntity findByIdWithStore(Long id);
 	SamlUserEntity findByPersistent(String spId, String idpId, String persistentId);

--- a/bwreg-jpa/src/main/java/edu/kit/scc/webreg/dao/SshPubKeyDao.java
+++ b/bwreg-jpa/src/main/java/edu/kit/scc/webreg/dao/SshPubKeyDao.java
@@ -32,4 +32,8 @@ public interface SshPubKeyDao extends BaseDao<SshPubKeyEntity> {
 	List<SshPubKeyEntity> findKeysToExpire(int limit);
 
 	List<SshPubKeyEntity> findKeysToExpiryWarning(int limit, int days);
+
+	List<SshPubKeyEntity> findByIdentityAndExpiryInDays(Long id, Integer days);
+
+	List<SshPubKeyEntity> findByExpiryInDays(Integer days);
 }

--- a/bwreg-jpa/src/main/java/edu/kit/scc/webreg/dao/jpa/JpaSamlUserDao.java
+++ b/bwreg-jpa/src/main/java/edu/kit/scc/webreg/dao/jpa/JpaSamlUserDao.java
@@ -53,31 +53,6 @@ public class JpaSamlUserDao extends JpaBaseDao<SamlUserEntity> implements SamlUs
 	}	
 
 	@Override
-	public SamlUserEntity findByPersistentWithRoles(String spId, String idpId, String persistentId) {
-		CriteriaBuilder builder = em.getCriteriaBuilder();
-		CriteriaQuery<SamlUserEntity> criteria = builder.createQuery(SamlUserEntity.class);
-		Root<SamlUserEntity> user = criteria.from(SamlUserEntity.class);
-		criteria.where(builder.and(
-				builder.equal(user.get("persistentSpId"), spId),
-				builder.equal(user.get("persistentIdpId"), idpId),
-				builder.equal(user.get("persistentId"), persistentId)
-				));
-		criteria.select(user);
-		criteria.distinct(true);
-		user.fetch("roles", JoinType.LEFT);
-		user.fetch("groups", JoinType.LEFT);
-		user.fetch("genericStore", JoinType.LEFT);
-		user.fetch("attributeStore", JoinType.LEFT);
-		
-		try {
-			return em.createQuery(criteria).getSingleResult();
-		}
-		catch (NoResultException e) {
-			return null;
-		}			
-	}	
-
-	@Override
 	public SamlUserEntity findByPersistent(String spId, String idpId, String persistentId) {
 		
 		TypedQuery<SamlUserEntity> query = em.createQuery("select u from SamlUserEntity u where u.persistentSpId = :spId and u.idp.entityId = :idpId and "

--- a/bwreg-jpa/src/main/java/edu/kit/scc/webreg/dao/jpa/JpaSshPubKeyDao.java
+++ b/bwreg-jpa/src/main/java/edu/kit/scc/webreg/dao/jpa/JpaSshPubKeyDao.java
@@ -12,6 +12,7 @@ package edu.kit.scc.webreg.dao.jpa;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
@@ -63,9 +64,36 @@ public class JpaSshPubKeyDao extends JpaBaseDao<SshPubKeyEntity> implements SshP
 	@Override
 	@SuppressWarnings("unchecked")
 	public List<SshPubKeyEntity> findByIdentityAndKey(Long identityId, String encodedKey) {
-		return em.createQuery("select e from SshPubKeyEntity e where e.identity.id = :userId and e.encodedKey = :encodedKey")
+		return em.createQuery("select e from SshPubKeyEntity e where e.identity.id = :identityId and e.encodedKey = :encodedKey")
 				.setParameter("identityId", identityId)
 				.setParameter("encodedKey", encodedKey)
+				.getResultList();	
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public List<SshPubKeyEntity> findByIdentityAndExpiryInDays(Long identityId, Integer days) {
+		Date currentDate = new Date();
+        Calendar c = Calendar.getInstance();
+        c.setTime(currentDate);
+        c.add(Calendar.DATE, days);
+        Date expiryDatePlusN = c.getTime();
+		return em.createQuery("select e from SshPubKeyEntity e where e.identity.id = :identityId and e.expiresAt < :expiryDatePlusN")
+				.setParameter("identityId", identityId)
+				.setParameter("expiryDatePlusN", expiryDatePlusN)
+				.getResultList();	
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public List<SshPubKeyEntity> findByExpiryInDays(Integer days) {
+		Date currentDate = new Date();
+        Calendar c = Calendar.getInstance();
+        c.setTime(currentDate);
+        c.add(Calendar.DATE, days);
+        Date expiryDatePlusN = c.getTime();
+		return em.createQuery("select e from SshPubKeyEntity e where e.expiresAt < :expiryDatePlusN")
+				.setParameter("expiryDatePlusN", expiryDatePlusN)
 				.getResultList();	
 	}
 

--- a/bwreg-service/src/main/java/edu/kit/scc/webreg/dto/service/SshPubKeyDtoService.java
+++ b/bwreg-service/src/main/java/edu/kit/scc/webreg/dto/service/SshPubKeyDtoService.java
@@ -14,4 +14,10 @@ public interface SshPubKeyDtoService extends BaseDtoService<SshPubKeyEntity, Ssh
 	List<SshPubKeyEntityDto> findByUidNumberAndStatus(Long uidNumber, SshPubKeyStatus keyStatus)
 			throws RestInterfaceException;
 
+	List<SshPubKeyEntityDto> findByUidNumberAndExpiryInDays(Long uidNumber, Integer days)
+			throws RestInterfaceException;
+
+	List<SshPubKeyEntityDto> findByExpiryInDays(Integer days)
+			throws RestInterfaceException;
+
 }

--- a/bwreg-service/src/main/java/edu/kit/scc/webreg/dto/service/SshPubKeyDtoServiceImpl.java
+++ b/bwreg-service/src/main/java/edu/kit/scc/webreg/dto/service/SshPubKeyDtoServiceImpl.java
@@ -49,6 +49,22 @@ public class SshPubKeyDtoServiceImpl extends BaseDtoServiceImpl<SshPubKeyEntity,
 		return convertList(list);
 	}	
 	
+	@Override
+	public List<SshPubKeyEntityDto> findByUidNumberAndExpiryInDays(Long uidNumber, Integer days) throws RestInterfaceException {
+		UserEntity user = userDao.findByUidNumber(uidNumber);
+		
+		List<SshPubKeyEntity> list = dao.findByIdentityAndExpiryInDays(user.getIdentity().getId(), days);
+		
+		return convertList(list);
+	}
+
+	@Override
+	public List<SshPubKeyEntityDto> findByExpiryInDays(Integer days) throws RestInterfaceException {
+		List<SshPubKeyEntity> list = dao.findByExpiryInDays(days);
+		
+		return convertList(list);
+	}
+
 	protected List<SshPubKeyEntityDto> convertList(List<SshPubKeyEntity> list) {
 		List<SshPubKeyEntityDto> dtoList = new ArrayList<SshPubKeyEntityDto>(list.size());
 		

--- a/bwreg-service/src/main/java/edu/kit/scc/webreg/service/UserService.java
+++ b/bwreg-service/src/main/java/edu/kit/scc/webreg/service/UserService.java
@@ -28,9 +28,6 @@ import edu.kit.scc.webreg.exc.UserUpdateException;
 
 public interface UserService extends BaseService<UserEntity> {
 
-	SamlUserEntity findByPersistentWithRoles(String spId, String idpId,
-			String persistentId);
-	
 	List<UserEntity> findByEppn(String eppn);
 	
 	UserEntity findByIdWithAll(Long id);
@@ -68,5 +65,7 @@ public interface UserService extends BaseService<UserEntity> {
 
 	SamlUserEntity updateUserFromIdp(SamlUserEntity user, String executor, StringBuffer debugLog)
 			throws UserUpdateException;
+
+	SamlUserEntity findByPersistent(String spId, String idpId, String persistentId);
 
 }

--- a/bwreg-service/src/main/java/edu/kit/scc/webreg/service/identity/IdentityCreater.java
+++ b/bwreg-service/src/main/java/edu/kit/scc/webreg/service/identity/IdentityCreater.java
@@ -51,6 +51,10 @@ public class IdentityCreater implements Serializable {
 			logger.debug("No local generated username for identity {}. Generating one...", user.getIdentity());
 			String generatedName = RandomStringUtils.randomAlphabetic(3).toLowerCase() + RandomStringUtils.randomNumeric(4);
 			logger.debug("Generated username for identity {}: {}", user.getIdentity(), generatedName);
+			while (dao.findByAttr("generatedLocalUsername", generatedName) != null) {
+				generatedName = RandomStringUtils.randomAlphabetic(3).toLowerCase() + RandomStringUtils.randomNumeric(4);
+				logger.debug("Generated username is already taken. Try again for identity {}: {}", user.getIdentity(), generatedName);
+			}
 			user.getIdentity().setGeneratedLocalUsername(generatedName);
 		}
 	}

--- a/bwreg-service/src/main/java/edu/kit/scc/webreg/service/impl/UserServiceImpl.java
+++ b/bwreg-service/src/main/java/edu/kit/scc/webreg/service/impl/UserServiceImpl.java
@@ -94,6 +94,11 @@ public class UserServiceImpl extends BaseServiceImpl<UserEntity> implements User
 	}
 
 	@Override
+	public SamlUserEntity findByPersistent(String spId, String idpId, String persistentId) {
+		return samlUserDao.findByPersistent(spId, idpId, persistentId);
+	}
+	
+	@Override
 	public List<UserEntity> findByIdentity(IdentityEntity identity) {
 		return dao.findByIdentity(identity);
 	}
@@ -111,11 +116,6 @@ public class UserServiceImpl extends BaseServiceImpl<UserEntity> implements User
     @Override
 	public List<UserEntity> findGenericStoreKeyWithLimit(String key, Integer limit) {
 		return dao.findGenericStoreKeyWithLimit(key, limit);
-	}
-	
-	@Override
-	public SamlUserEntity findByPersistentWithRoles(String spId, String idpId, String persistentId) {
-		return samlUserDao.findByPersistentWithRoles(spId, idpId, persistentId);
 	}
 
 	@Override

--- a/bwreg-service/src/main/java/edu/kit/scc/webreg/service/oidc/client/OidcDiscoverySingletonBean.java
+++ b/bwreg-service/src/main/java/edu/kit/scc/webreg/service/oidc/client/OidcDiscoverySingletonBean.java
@@ -1,0 +1,75 @@
+package edu.kit.scc.webreg.service.oidc.client;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import javax.ejb.Singleton;
+import javax.inject.Inject;
+import javax.script.Invocable;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+
+import org.slf4j.Logger;
+
+import edu.kit.scc.webreg.entity.ScriptEntity;
+import edu.kit.scc.webreg.entity.oidc.OidcRpConfigurationEntity;
+import edu.kit.scc.webreg.service.oidc.OidcRpConfigurationService;
+
+@Singleton
+public class OidcDiscoverySingletonBean {
+
+	@Inject
+	private Logger logger;
+
+	@Inject
+	private OidcRpConfigurationService oidcRpService;
+	
+	public List<OidcRpConfigurationEntity> getFilteredOpList(ScriptEntity scriptEntity) {
+		
+		ScriptEngine engine = (new ScriptEngineManager()).getEngineByName(scriptEntity.getScriptEngine());
+		
+		List<OidcRpConfigurationEntity> tempList = oidcRpService.findAll();
+		Collections.sort(tempList, idpOrgComparator);
+
+		if (engine == null) {
+			logger.warn("No engine set for script {}. Returning all IDPs", scriptEntity.getName());
+			return tempList;
+		}
+		
+		try {
+			List<OidcRpConfigurationEntity> targetList = new ArrayList<OidcRpConfigurationEntity>();
+
+			engine.eval(scriptEntity.getScript());
+
+			Invocable invocable = (Invocable) engine;
+			
+			invocable.invokeFunction("filterOps", tempList, targetList, logger);
+
+			Collections.sort(targetList, idpOrgComparator);
+
+			return targetList;
+		} catch (ScriptException e) {
+			logger.warn("Script execution failed.", e);
+			return tempList;
+		} catch (NoSuchMethodException e) {
+			logger.info("No filterOs method in script. returning all Idps");
+			return tempList;
+		}
+	}
+	
+	private Comparator<OidcRpConfigurationEntity> idpOrgComparator = new Comparator<OidcRpConfigurationEntity>() {
+
+		@Override
+		public int compare(OidcRpConfigurationEntity op1, OidcRpConfigurationEntity op2) {
+			if (op1 != null && op1.getDisplayName() != null &&
+					op2 != null && op2.getDisplayName() != null)
+				return op1.getDisplayName().compareTo(op2.getDisplayName());
+			else
+				return 0;
+		}
+		
+	};	
+}

--- a/bwreg-service/src/main/java/edu/kit/scc/webreg/service/reg/ldap/LdapWorker.java
+++ b/bwreg-service/src/main/java/edu/kit/scc/webreg/service/reg/ldap/LdapWorker.java
@@ -4,32 +4,11 @@
  * are made available under the terms of the GNU Public License v3.0
  * which accompanies this distribution, and is available at
  * http://www.gnu.org/licenses/gpl.html
- * 
+ *
  * Contributors:
  *     Michael Simon - initial
  ******************************************************************************/
 package edu.kit.scc.webreg.service.reg.ldap;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-
-import javax.naming.NamingEnumeration;
-import javax.naming.NamingException;
-import javax.naming.directory.Attribute;
-import javax.naming.directory.Attributes;
-import javax.naming.directory.DirContext;
-import javax.naming.directory.ModificationItem;
-import javax.naming.directory.SearchResult;
-
-import org.apache.commons.collections.IteratorUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import edu.kit.scc.webreg.audit.Auditor;
 import edu.kit.scc.webreg.entity.UserEntity;
@@ -42,75 +21,154 @@ import edu.vt.middleware.ldap.AttributesFactory;
 import edu.vt.middleware.ldap.Ldap;
 import edu.vt.middleware.ldap.Ldap.AttributeModification;
 import edu.vt.middleware.ldap.SearchFilter;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.ModificationItem;
+import javax.naming.directory.SearchResult;
+import org.apache.commons.collections.IteratorUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LdapWorker {
 
 	private static Logger logger = LoggerFactory.getLogger(LdapWorker.class);
-	
+
 	private String ldapUserBase;
 	private String ldapGroupBase;
-    private String ldapUserObjectclasses;
-    private String ldapGroupObjectclasses;
-	
+        private String ldapUserObjectclasses;
+        private String ldapGroupObjectclasses;
+
 	private String ldapGroupType;
 	private String ldapGroupMemberBase;
-	
+
 	private boolean sambaEnabled;
 	private String sidPrefix;
-	
+
+        // optional feature: marking LDAP accounts as active/deactivated without deleting them
+        private String activationAttributeName; // LDAP attribute name to use; required to use feature
+        private String activeValue; // optional custom "active" value replacement
+        private String nonActiveValue; // optional custom "deactivated" value replacement
+
 	private LdapConnectionManager connectionManager;
-	
+
 	private Auditor auditor;
 
 	public LdapWorker(PropertyReader prop, Auditor auditor, boolean sambaEnabled) throws RegisterException {
 		this.auditor = auditor;
 		this.sambaEnabled = sambaEnabled;
-		
+
 		try {
 			connectionManager = new LdapConnectionManager(prop);
 			ldapUserBase = prop.readProp("ldap_user_base");
 			ldapGroupBase = prop.readProp("ldap_group_base");
-                        
+
 			ldapUserObjectclasses = prop.readPropOrNull("ldap_user_objectclass");
 			ldapGroupObjectclasses = prop.readPropOrNull("ldap_group_objectclass");
 
 			ldapGroupType = prop.readPropOrNull("group_type");
 			ldapGroupMemberBase = prop.readPropOrNull("ldap_group_member_base");
 
+                        activationAttributeName = prop.readPropOrNull("ldap_activation_attribute_name");
+                        activeValue = prop.readPropOrNull("ldap_activation_attribute_positive_value");
+                        nonActiveValue = prop.readPropOrNull("ldap_activation_attribute_negative_value");
+
 			if (sambaEnabled)
 				sidPrefix = prop.readProp("sid_prefix");
-			
+
 
 		} catch (PropertyReaderException e) {
 			throw new RegisterException(e);
-		}		
+		}
+	}
+
+        /**
+         * For a given ldap this will set an attribute attrName associated with
+         * the supplied dn to attrValue, creating the attribute as necessary.
+         *
+         * @param  ldap  <code>Ldap</code> LDAP connection to work on
+         * @param  dn  <code>String</code> named object in the LDAP
+         * @param  attrName  <code>String</code> name of the attribute to set
+         * @param  attrValue  <code>Object</code> value to set the attribute to
+         *
+         * @throws javax.naming.NamingException
+         */
+        private void setAttribute(Ldap ldap, String dn, String attrName, Object attrValue) throws NamingException {
+                Attributes attrs = ldap.getAttributes(dn);
+                if (attrs.get(attrName) == null) {
+                        ldap.modifyAttributes(dn, AttributeModification.ADD,
+                                AttributesFactory.createAttributes(attrName, attrValue));
+                }
+                else {
+                        ldap.modifyAttributes(dn, AttributeModification.REPLACE,
+                                AttributesFactory.createAttributes(attrName, attrValue));
+                }
+        }
+
+        /**
+         * This will set the LDAP attribute with the name specified in
+         * activationAttributeName of the user's account associated with
+         * the given uid to the value specified in nonActiveValue
+         * (or "deactivated" by default), marking the account as inactive,
+         * without actually deleting it.
+         *
+         * @param  uid  <code>String</code> ID of the target user
+         */
+        private void deactivateAccount(String uid) {
+                String ldapDn = "uid=" + uid + "," + ldapUserBase;
+                for (Ldap ldap : connectionManager.getConnections()) {
+                        try {
+                                setAttribute(ldap, ldapDn, activationAttributeName, nonActiveValue == null ? "deactivated" : nonActiveValue);
+                                logger.info("Deactivated account {} in ldap {} with value {}",
+                                            new Object[] {uid, ldapUserBase, nonActiveValue});
+                                auditor.logAction("", "DEACTIVATE LDAP ACCOUNT", uid, "Account deactivated in "
+                                        + ldap.getLdapConfig().getLdapUrl(), AuditStatus.SUCCESS);
+                        } catch (NamingException e) {
+                                logger.warn("FAILED: Deactivate account {} in ldap {}: {}",
+                                        new Object[] {uid, ldapUserBase, e.getMessage()});
+                                auditor.logAction("", "DEACTIVATE LDAP ACCOUNT", uid, "Account deactivation failed in "
+                                        + ldap.getLdapConfig().getLdapUrl(), AuditStatus.FAIL);
+                        }
+                }
 	}
 
 	public void deleteUser(String uid) {
-
-		for (Ldap ldap : connectionManager.getConnections()) {
-			try {
-				ldap.delete("uid=" + uid + "," + ldapUserBase);
-				logger.info("Deleted User {} from ldap {}", 
-						new Object[] {uid, ldapUserBase});
-				auditor.logAction("", "DELETE LDAP USER", uid, "User deleted in " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.SUCCESS);
-			} catch (NamingException e) {
-				logger.warn("FAILED: Delete User {} from ldap {}: {}", 
-						new Object[] {uid, ldapUserBase, e.getMessage()});
-				auditor.logAction("", "DELETE LDAP USER", uid, "User deletion failed in " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.FAIL);
-			}
-		}
+                if (activationAttributeName == null || activationAttributeName.isBlank()) {
+                    for (Ldap ldap : connectionManager.getConnections()) {
+                            try {
+                                    ldap.delete("uid=" + uid + "," + ldapUserBase);
+                                    logger.info("Deleted User {} from ldap {}",
+                                                    new Object[] {uid, ldapUserBase});
+                                    auditor.logAction("", "DELETE LDAP USER", uid, "User deleted in " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.SUCCESS);
+                            } catch (NamingException e) {
+                                    logger.warn("FAILED: Delete User {} from ldap {}: {}",
+                                                    new Object[] {uid, ldapUserBase, e.getMessage()});
+                                    auditor.logAction("", "DELETE LDAP USER", uid, "User deletion failed in " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.FAIL);
+                            }
+                    }
+                } else {
+                    deactivateAccount(uid);
+                }
 	}
-	
+
 	public void reconGroup(String cn, String gidNumber, Set<String> memberUids) {
 		String dn = "cn=" + cn + "," + ldapGroupBase;
 
 		Boolean groupOfNames = false;
-		if (ldapGroupType != null && ldapGroupMemberBase != null 
+		if (ldapGroupType != null && ldapGroupMemberBase != null
 				&& ldapGroupType.equals("member")) {
 			groupOfNames = true;
 		}
-		
+
 		if (memberUids.size() == 0) {
 			deleteGroup(cn);
 			return;
@@ -120,7 +178,7 @@ public class LdapWorker {
 		if (groupOfNames) {
 			createGroup(ldapGroupMemberBase, cn, gidNumber, true);
 		}
-		
+
 		/*
 		 * First run for posix nis groups
 		 */
@@ -137,7 +195,7 @@ public class LdapWorker {
 						oldMemberUids.add(memberUid);
 					}
 				}
-				
+
 				Set<String> addMemberUids = new HashSet<String>(memberUids);
 				addMemberUids.removeAll(oldMemberUids);
 
@@ -147,18 +205,18 @@ public class LdapWorker {
 				for (String memberUid : addMemberUids) {
 					logger.info("Adding member {} to group {}", memberUid, cn);
 					try {
-						ldap.modifyAttributes(dn, AttributeModification.ADD, 
+						ldap.modifyAttributes(dn, AttributeModification.ADD,
 								AttributesFactory.createAttributes("memberUid", memberUid));
 						auditor.logAction(cn, "ADD LDAP GROUP MEMBER", memberUid, "Added member on " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.SUCCESS);
 					} catch (NamingException e) {
 						auditor.logAction(cn, "ADD LDAP GROUP MEMBER", memberUid, "Add member on " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.FAIL);
 					}
 				}
-				
+
 				for (String memberUid : removeMemberUids) {
 					logger.info("Removing member {} from group {}", memberUid, cn);
 					try {
-						ldap.modifyAttributes(dn, AttributeModification.REMOVE, 
+						ldap.modifyAttributes(dn, AttributeModification.REMOVE,
 								AttributesFactory.createAttributes("memberUid", memberUid));
 						auditor.logAction(cn, "REMOVE LDAP GROUP MEMBER", memberUid, "Removed member on " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.SUCCESS);
 					} catch (NamingException e) {
@@ -171,7 +229,7 @@ public class LdapWorker {
 					logger.info("Group action failed for connection " + ldap.getLdapConfig().getLdapUrl(), e);
 				else
 					logger.info("Group action failed, and oh no, ldapConfig is null!", e);
-			}			
+			}
 		}
 
 		/*
@@ -185,7 +243,7 @@ public class LdapWorker {
 			for (String memberUid : memberUids) {
 				members.add("uid=" + memberUid + "," + ldapUserBase);
 			}
-			
+
 			for (Ldap ldap : connectionManager.getConnections()) {
 				try {
 					Set<String> oldMembers = new HashSet<String>();
@@ -199,7 +257,7 @@ public class LdapWorker {
 							oldMembers.add(member);
 						}
 					}
-					
+
 					Set<String> addMembers = new HashSet<String>(members);
 					addMembers.removeAll(oldMembers);
 
@@ -209,9 +267,9 @@ public class LdapWorker {
 					for (String member : addMembers) {
 						logger.info("Adding member {} to group {}", member, cn);
 						try {
-							ldap.modifyAttributes(dn, AttributeModification.ADD, 
+							ldap.modifyAttributes(dn, AttributeModification.ADD,
 									AttributesFactory.createAttributes("member", member));
-							ldap.modifyAttributes(member, AttributeModification.ADD, 
+							ldap.modifyAttributes(member, AttributeModification.ADD,
 									AttributesFactory.createAttributes("memberOf", dn));
 							auditor.logAction(cn, "ADD LDAP GROUP MEMBER", member, "Added member on " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.SUCCESS);
 						} catch (NamingException e) {
@@ -219,13 +277,13 @@ public class LdapWorker {
 							auditor.logAction(cn, "ADD LDAP GROUP MEMBER", member, "Add member on " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.FAIL);
 						}
 					}
-					
+
 					for (String member : removeMembers) {
 						logger.info("Removing member {} from group {}", member, cn);
 						try {
-							ldap.modifyAttributes(dn, AttributeModification.REMOVE, 
+							ldap.modifyAttributes(dn, AttributeModification.REMOVE,
 									AttributesFactory.createAttributes("member", member));
-							ldap.modifyAttributes(member, AttributeModification.REMOVE, 
+							ldap.modifyAttributes(member, AttributeModification.REMOVE,
 									AttributesFactory.createAttributes("memberOf", dn));
 							auditor.logAction(cn, "REMOVE LDAP GROUP MEMBER", member, "Removed member on " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.SUCCESS);
 						} catch (NamingException e) {
@@ -239,21 +297,21 @@ public class LdapWorker {
 						logger.info("Group action failed for connection " + ldap.getLdapConfig().getLdapUrl(), e);
 					else
 						logger.info("Group action failed, and oh no, ldapConfig is null!", e);
-				}			
-			}				
+				}
+			}
 		}
 	}
-	
+
 	public void deleteGroup(String cn) {
 
 		for (Ldap ldap : connectionManager.getConnections()) {
 			try {
 				ldap.delete("cn=" + cn + "," + ldapGroupBase);
-				logger.info("Deleted Group {} from ldap {}", 
+				logger.info("Deleted Group {} from ldap {}",
 						new Object[] {cn, ldapGroupBase});
 				auditor.logAction("", "DELETE LDAP GROUP", cn, "Group deleted in " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.SUCCESS);
 			} catch (NamingException e) {
-				logger.warn("FAILED: Delete Group {} from ldap {}", 
+				logger.warn("FAILED: Delete Group {} from ldap {}",
 						new Object[] {cn, ldapUserBase});
 				auditor.logAction("", "DELETE LDAP GROUP", cn, "Group deletion failed in " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.FAIL);
 			}
@@ -264,7 +322,7 @@ public class LdapWorker {
 			String homeDir, String description) {
 		reconUser(cn, sn, givenName, mail, uid, uidNumber, gidNumber, homeDir, description, null);
 	}
-	
+
 	public void reconUser(String cn, String sn, String givenName, String mail, String uid, String uidNumber, String gidNumber,
 			String homeDir, String description, Map<String, String> extraAttributesMap) {
 		for (Ldap ldap : connectionManager.getConnections()) {
@@ -277,24 +335,24 @@ public class LdapWorker {
 					dnList.add(sr.getName());
 				}
 			} catch (NamingException e) {
-				logger.warn("FAILED: Search user {}, uid:{}, gid:{} with ldap {}: {}", 
-						new Object[] {uid, uidNumber, gidNumber, 
+				logger.warn("FAILED: Search user {}, uid:{}, gid:{} with ldap {}: {}",
+						new Object[] {uid, uidNumber, gidNumber,
 						ldapUserBase, e.getMessage()});
 			}
-			
+
 			if (dnList.size() == 0) {
 				logger.debug("Account does not exist. Creating...");
 				try {
 					createUserIntern(ldap, cn, givenName, sn, mail, uid, uidNumber, gidNumber, homeDir, description, extraAttributesMap);
-					logger.info("User {},{} with ldap {} successfully created", 
+					logger.info("User {},{} with ldap {} successfully created",
 							new Object[] {uid, gidNumber, ldapUserBase});
 					auditor.logAction("", "RECON CREATE LDAP USER", uid, "User created in " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.SUCCESS);
 				} catch (NamingException ne) {
-					logger.warn("FAILED: User {}, uid:{}, gid:{} with ldap {}: {}", 
-							new Object[] {uid, uidNumber, gidNumber, 
+					logger.warn("FAILED: User {}, uid:{}, gid:{} with ldap {}: {}",
+							new Object[] {uid, uidNumber, gidNumber,
 							ldapUserBase, ne.getMessage()});
 					auditor.logAction("", "RECON CREATE LDAP USER", uid, "User creation failed in " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.FAIL);
-				}				
+				}
 			}
 			else {
 				if (dnList.size() > 1) {
@@ -304,21 +362,21 @@ public class LdapWorker {
 							ldap.delete(dnList.get(i));
 							auditor.logAction("", "DELETE LDAP USER", dnList.get(i), "User delete in " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.SUCCESS);
 						} catch (NamingException ne) {
-							logger.warn("FAILED: Delete user {}, uid:{}, gid:{} with ldap {}: {}", 
-									new Object[] {uid, uidNumber, gidNumber, 
+							logger.warn("FAILED: Delete user {}, uid:{}, gid:{} with ldap {}: {}",
+									new Object[] {uid, uidNumber, gidNumber,
 									ldapUserBase, ne.getMessage()});
 							auditor.logAction("", "DELETE LDAP USER", dnList.get(i), "User delete failed in " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.FAIL);
-						}				
+						}
 					}
 				}
-				
+
 				try {
 					String dn = dnList.get(0);
 					Attributes attrs = ldap.getAttributes(dn);
 
 					List<ModificationItem> modList = new ArrayList<ModificationItem>();
 					StringBuilder log = new StringBuilder();
-					
+
 					compareAttr(attrs, "cn", cn, modList, log);
 					compareAttr(attrs, "sn", sn, modList, log);
 					compareAttr(attrs, "givenName", givenName, modList, log);
@@ -327,12 +385,15 @@ public class LdapWorker {
 					compareAttr(attrs, "gidNumber", gidNumber, modList, log);
 					compareAttr(attrs, "homeDirectory", homeDir, modList, log);
 					compareAttr(attrs, "description", description, modList, log);
-					
+                                        if (activationAttributeName != null && !activationAttributeName.isBlank()) {
+                                            compareAttr(attrs, activationAttributeName, activeValue == null ? "active" : activeValue, modList, log);
+                                        }
+
 					if (sambaEnabled) {
 						addAttrIfNotExists(attrs, "objectClass", "sambaSamAccount", modList);
-						compareAttr(attrs, "sambaSID", sidPrefix + (Long.parseLong(uidNumber) * 2L + 1000L), modList, log);					
+						compareAttr(attrs, "sambaSID", sidPrefix + (Long.parseLong(uidNumber) * 2L + 1000L), modList, log);
 					}
-					
+
 					if (extraAttributesMap != null) {
 						for (Entry<String, String> extraAttribute : extraAttributesMap.entrySet()) {
 							if (extraAttribute.getKey().startsWith("extra_") && extraAttribute.getKey().length() > 6) {
@@ -340,7 +401,7 @@ public class LdapWorker {
 							}
 						}
 					}
-					
+
 					if (modList.size() == 0) {
 						logger.debug("No modification detected");
 					}
@@ -350,7 +411,7 @@ public class LdapWorker {
 						if (log.length() > 512) log.setLength(512);
 						auditor.logAction("", "RECON LDAP USER", uid, log.toString(), AuditStatus.SUCCESS);
 					}
-					
+
 					Attribute attr = attrs.get("uid");
 					if (attr != null) {
 						String oldUid = (String) attr.get();
@@ -359,25 +420,25 @@ public class LdapWorker {
 						}
 					}
 				} catch (NamingException e) {
-					logger.warn("FAILED: Recon user {}, uid:{}, gid:{} with ldap {}: {}", 
-							new Object[] {uid, uidNumber, gidNumber, 
+					logger.warn("FAILED: Recon user {}, uid:{}, gid:{} with ldap {}: {}",
+							new Object[] {uid, uidNumber, gidNumber,
 							ldapUserBase, e.getMessage()});
 					auditor.logAction("", "DELETE LDAP USER", uid, "User delete failed in " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.FAIL);
 				}
 			}
-		}		
+		}
 	}
 
 	@SuppressWarnings("unchecked")
 	public void createGroup(String base, String cn, String gidNumber, Boolean groupOfNames) {
-		
+
 		for (Ldap ldap : connectionManager.getConnections()) {
-			
+
 			try {
 				Iterator<SearchResult> resultIterator = ldap.search(base,
 						  new SearchFilter("(gidNumber=" + gidNumber + ")"), new String[]{"cn", "uid"});
 				List<SearchResult> resultList = IteratorUtils.toList(resultIterator);
-				
+
 				if (resultList.size() > 1) {
 					logger.warn("More than one Ldap Group ({}) with gid {}, delete all except one!", resultList.size(), gidNumber);
 					for (int i=1; i<resultList.size(); i++) {
@@ -388,12 +449,12 @@ public class LdapWorker {
 						auditor.logAction("", "DELETE LDAP GROUP", cn, "Group deleted in " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.SUCCESS);
 					}
 				}
-				
+
 				if (resultList.size() > 0) {
 					SearchResult sr = resultList.get(0);
 					Attribute cnAttr = sr.getAttributes().get("cn");
 					String actualCn = (String) cnAttr.get();
-					
+
 					if (! cn.equals(actualCn)) {
 						logger.warn("Groupname for group {} differs. is {}, should {}. Changing attrs dn, cn", gidNumber, actualCn, cn);
 						String dn = sr.getName();
@@ -402,29 +463,29 @@ public class LdapWorker {
 						logger.info("Rename Group {} ({}) completed", cn, gidNumber);
 						auditor.logAction("", "RENAME LDAP GROUP", cn, "Group renamed in " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.SUCCESS);
 					}
-					
+
 					continue;
 				}
-				
+
 			} catch (NamingException e) {
 				logger.warn("Ldap Error occured", e);
 			}
-			
+
 			try {
 				createGroupIntern(ldap, base, cn, gidNumber, groupOfNames);
-				logger.info("Group {},{} with ldap {} successfully created", 
+				logger.info("Group {},{} with ldap {} successfully created",
 						new Object[] {cn, gidNumber, ldapUserBase});
 				auditor.logAction("", "CREATE LDAP GROUP", cn, "Group created in " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.SUCCESS);
 			} catch (NamingException e) {
-				logger.warn("FAILED: Group cn:{}, gid:{} with ldap {}: {}", 
-						new Object[] {cn, gidNumber, 
+				logger.warn("FAILED: Group cn:{}, gid:{} with ldap {}: {}",
+						new Object[] {cn, gidNumber,
 						ldapUserBase, e.getMessage()});
 				auditor.logAction("", "CREATE LDAP GROUP", cn, "Group creation failed in " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.FAIL);
 			}
 
 		}
 	}
-	
+
 	public List<String> getPasswords(String uid) {
 		List<String> pwList = new ArrayList<String>();
 		for (Ldap ldap : connectionManager.getConnections()) {
@@ -438,41 +499,32 @@ public class LdapWorker {
 						if (attrObject != null)
 							pwList.add(new String((byte[]) attrObject));
 					}
-				}				
+				}
 			} catch (NamingException e) {
-				logger.warn("FAILED: Getting password for User {} in ldap {}: {}", 
+				logger.warn("FAILED: Getting password for User {} in ldap {}: {}",
 						new Object[] {uid, ldapUserBase, e.getMessage()});
 			}
 		}
-		
+
 		return pwList;
 	}
-	
+
 	public void setPassword(String uid, String password) {
 		for (Ldap ldap : connectionManager.getConnections()) {
 			try {
 				String ldapDn = "uid=" + uid + "," + ldapUserBase;
-				Attributes attrs = ldap.getAttributes(ldapDn);
-				Attribute attr = attrs.get("userPassword");
-				if (attr == null) {
-					ldap.modifyAttributes(ldapDn, AttributeModification.ADD, 
-							AttributesFactory.createAttributes("userPassword", password));
-				}
-				else {
-					ldap.modifyAttributes(ldapDn, AttributeModification.REPLACE, 
-							AttributesFactory.createAttributes("userPassword", password));
-				}
-				logger.info("Setting password for User {} in ldap {}", 
+                                setAttribute(ldap, ldapDn, "userPassword", password);
+				logger.info("Setting password for User {} in ldap {}",
 						new Object[] {uid, ldapUserBase});
 				auditor.logAction("", "SET PASSWORD LDAP USER", uid, "Set User password in " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.SUCCESS);
 			} catch (NamingException e) {
-				logger.warn("FAILED: Setting password for User {} in ldap {}: {}", 
+				logger.warn("FAILED: Setting password for User {} in ldap {}: {}",
 						new Object[] {uid, ldapUserBase, e.getMessage()});
 				auditor.logAction("", "SET PASSWORD LDAP USER", uid, "Set User password failed in " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.FAIL);
 			}
-		}		
+		}
 	}
-	
+
 	public void setSambaPassword(String uid, String password, UserEntity user) {
 		for (Ldap ldap : connectionManager.getConnections()) {
 			try {
@@ -480,14 +532,14 @@ public class LdapWorker {
 
 				List<ModificationItem> modList = new ArrayList<ModificationItem>();
 				StringBuilder log = new StringBuilder();
-				
+
 				addAttrIfNotExists(attrs, "objectClass", "sambaSamAccount", modList);
 				compareAttr(attrs, "sambaSID", sidPrefix + (user.getUidNumber().longValue() * 2L + 1000L), modList, log);
 				compareAttr(attrs, "sambaNTPassword", password, modList, log);
 				compareAttr(attrs, "sambaPasswordHistory", "00000000000000000000000000000000000000000000000000000000", modList, log);
 				compareAttr(attrs, "sambaPwdLastSet", "1366812351", modList, log);
 				compareAttr(attrs, "sambaAcctFlags", "[U          ]", modList, log);
-				
+
 				if (modList.size() == 0) {
 					logger.debug("No modification detected");
 				}
@@ -498,11 +550,11 @@ public class LdapWorker {
 
 				auditor.logAction("", "SET SAMBA PASSWORD LDAP USER", uid, "Set User samba password in " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.SUCCESS);
 			} catch (NamingException e) {
-				logger.warn("FAILED: Setting password for User {} in ldap {}: {}", 
+				logger.warn("FAILED: Setting password for User {} in ldap {}: {}",
 						new Object[] {uid, ldapUserBase, e.getMessage()});
 				auditor.logAction("", "SET SAMBA PASSWORD LDAP USER", uid, "Set User samba password failed in " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.FAIL);
 			}
-		}		
+		}
 	}
 
 	public void deletePassword(String uid) {
@@ -512,24 +564,24 @@ public class LdapWorker {
 				Attributes attrs = ldap.getAttributes(ldapDn);
 				Attribute attr = attrs.get("userPassword");
 				if (attr != null) {
-					ldap.modifyAttributes(ldapDn, AttributeModification.REMOVE, 
+					ldap.modifyAttributes(ldapDn, AttributeModification.REMOVE,
 							AttributesFactory.createAttributes("userPassword"));
 				}
-				logger.info("Delete password for User {} in ldap {}", 
+				logger.info("Delete password for User {} in ldap {}",
 						new Object[] {uid, ldapUserBase});
 				auditor.logAction("", "DELETE PASSWORD LDAP USER", uid, "Delete User password in " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.SUCCESS);
 			} catch (NamingException e) {
-				logger.warn("FAILED: Setting password for User {} in ldap {}: {}", 
+				logger.warn("FAILED: Setting password for User {} in ldap {}: {}",
 						new Object[] {uid, ldapUserBase, e.getMessage()});
 				auditor.logAction("", "DELETE PASSWORD LDAP USER", uid, "Delete User password failed in " + ldap.getLdapConfig().getLdapUrl(), AuditStatus.FAIL);
 			}
-		}		
+		}
 	}
-		
+
 	public void getInfo(Infotainment info, String uid) {
 		InfotainmentTreeNode root = new InfotainmentTreeNode("root", null);
 		info.setRoot(root);
-		
+
 		int i = 0;
 		int fail = 0;
 		for (Ldap ldap : connectionManager.getConnections()) {
@@ -538,15 +590,15 @@ public class LdapWorker {
 				String ldapDn = "uid=" + uid + "," + ldapUserBase;
 				Attributes attrs = ldap.getAttributes(ldapDn);
 				new InfotainmentTreeNode("Server " + i, "Fetching Account success", root);
-				
+
 			} catch (NamingException e) {
-				logger.warn("FAILED: Getting info for User {} in ldap {}: {}", 
+				logger.warn("FAILED: Getting info for User {} in ldap {}: {}",
 						new Object[] {uid, ldapUserBase, e.getMessage()});
 				new InfotainmentTreeNode("Server " + i, "Fetching Account failed", root);
 				fail++;
 			}
 		}
-		
+
 		if (fail == 0)
 			info.setMessage("Fetching Account from " + i + " Server(s): Success");
 		else if (fail < i)
@@ -554,11 +606,11 @@ public class LdapWorker {
 		else
 			info.setMessage("Fetching Account from " + i + " Server(s): Failed!");
 	}
-		
+
 	public void getInfoForAdmin(Infotainment info, String uid) {
 		InfotainmentTreeNode root = new InfotainmentTreeNode("root", null);
 		info.setRoot(root);
-		
+
 		int i = 0;
 		int fail = 0;
 		for (Ldap ldap : connectionManager.getConnections()) {
@@ -571,9 +623,9 @@ public class LdapWorker {
 				while (attrEnumeration.hasMoreElements()) {
 					Attribute attr = (Attribute) attrEnumeration.nextElement();
 					new InfotainmentTreeNode(attr.getID(), attr.get().toString(), ldapNode);
-				}					
-				
-				Iterator<SearchResult> iterator = ldap.search(ldapGroupBase, new SearchFilter("(memberUid=" + uid + ")"), 
+				}
+
+				Iterator<SearchResult> iterator = ldap.search(ldapGroupBase, new SearchFilter("(memberUid=" + uid + ")"),
 						new String[] {"gidNumber", "cn"});
 
 				InfotainmentTreeNode ldapGroupNode = new InfotainmentTreeNode(ldap.getLdapConfig().getLdapUrl(), "Fetching groups ok", root);
@@ -587,13 +639,13 @@ public class LdapWorker {
 					}
 				}
 			} catch (NamingException e) {
-				logger.warn("FAILED: Getting info for User {} in ldap {}: {}", 
+				logger.warn("FAILED: Getting info for User {} in ldap {}: {}",
 						new Object[] {uid, ldapUserBase, e.getMessage()});
 				new InfotainmentTreeNode(ldap.getLdapConfig().getLdapUrl(), "Fetching attributes failed", root);
 				fail++;
 			}
 		}
-		
+
 		if (fail == 0)
 			info.setMessage("Fetching Account from " + i + " Server(s): Success");
 		else if (fail < i)
@@ -601,17 +653,17 @@ public class LdapWorker {
 		else
 			info.setMessage("Fetching Account from " + i + " Server(s): Failed!");
 	}
-		
+
 	public void closeConnections() {
 		connectionManager.closeConnections();
 	}
-	
-	private void addAttrIfNotExists(Attributes attrs, String key, String value, List<ModificationItem> modList) 
+
+	private void addAttrIfNotExists(Attributes attrs, String key, String value, List<ModificationItem> modList)
 			throws NamingException {
 		Attribute attr = attrs.get(key);
 
 		if (attr == null) {
-			modList.add(new ModificationItem(DirContext.ADD_ATTRIBUTE, 
+			modList.add(new ModificationItem(DirContext.ADD_ATTRIBUTE,
 					AttributesFactory.createAttribute(key, value)));
 		}
 		else {
@@ -620,18 +672,18 @@ public class LdapWorker {
 					return;
 				}
 			}
-			modList.add(new ModificationItem(DirContext.ADD_ATTRIBUTE, 
+			modList.add(new ModificationItem(DirContext.ADD_ATTRIBUTE,
 					AttributesFactory.createAttribute(key, value)));
 		}
 	}
-	
+
 	private void compareAttr(Attributes attrs, String key, String value, List<ModificationItem> modList,
 				StringBuilder log)
 			throws NamingException {
 		Attribute attr = attrs.get(key);
-		
+
 		if (attr == null) {
-			modList.add(new ModificationItem(DirContext.ADD_ATTRIBUTE, 
+			modList.add(new ModificationItem(DirContext.ADD_ATTRIBUTE,
 					AttributesFactory.createAttribute(key, value)));
 			log.append("ADD: ");
 			log.append(key);
@@ -640,7 +692,7 @@ public class LdapWorker {
 			log.append(" ");
 		}
 		else if (! attr.get().equals(value)) {
-			modList.add(new ModificationItem(DirContext.REPLACE_ATTRIBUTE, 
+			modList.add(new ModificationItem(DirContext.REPLACE_ATTRIBUTE,
 					AttributesFactory.createAttribute(key, value)));
 			log.append("REPLACE: ");
 			log.append(key);
@@ -651,18 +703,18 @@ public class LdapWorker {
 			log.append(" ");
 		}
 	}
-	
+
 	private void createUserIntern(Ldap ldap, String cn, String givenName, String sn, String mail, String uid, String uidNumber, String gidNumber,
 			String homeDir, String description, Map<String, String> extraAttributesMap) throws NamingException {
 		Attributes attrs;
-                
-		if (ldapUserObjectclasses == null || ldapUserObjectclasses.trim().isEmpty())
+
+		if (ldapUserObjectclasses == null || ldapUserObjectclasses.isBlank())
 			ldapUserObjectclasses = "top person organizationalPerson inetOrgPerson posixAccount";
-		
+
 		if (sambaEnabled) {
 			if (!ldapUserObjectclasses.matches("(?:\\s|.)*?\\bsambaSamAccount\\b(?:\\s|.)*"))
 				ldapUserObjectclasses += " sambaSamAccount";
-                        
+
 			attrs = AttributesFactory.createAttributes("objectClass",
                                 ldapUserObjectclasses.split("\\s+"));
 			attrs.put(AttributesFactory.createAttribute("sambaSID", sidPrefix + (Long.parseLong(uidNumber) * 2L + 1000L)));
@@ -671,7 +723,7 @@ public class LdapWorker {
 			attrs = AttributesFactory.createAttributes("objectClass",
                                 ldapUserObjectclasses.split("\\s+"));
 		}
-		
+
 		attrs.put(AttributesFactory.createAttribute("cn", cn));
 		attrs.put(AttributesFactory.createAttribute("sn", sn));
 		attrs.put(AttributesFactory.createAttribute("givenName", givenName));
@@ -681,6 +733,9 @@ public class LdapWorker {
 		attrs.put(AttributesFactory.createAttribute("gidNumber", gidNumber));
 		attrs.put(AttributesFactory.createAttribute("homeDirectory", homeDir));
 		attrs.put(AttributesFactory.createAttribute("description", description));
+                if (activationAttributeName != null && !activationAttributeName.isBlank()) {
+                    attrs.put(AttributesFactory.createAttribute(activationAttributeName, activeValue == null ? "active" : activeValue));
+                }
 
 		if (extraAttributesMap != null) {
 			for (Entry<String, String> extraAttribute : extraAttributesMap.entrySet()) {
@@ -689,41 +744,41 @@ public class LdapWorker {
 				}
 			}
 		}
-		
+
 		ldap.create("uid=" + uid + "," + ldapUserBase, attrs);
 	}
-	
-	private void createGroupIntern(Ldap ldap, String base, String cn, String gidNumber, Boolean groupOfNames) 
+
+	private void createGroupIntern(Ldap ldap, String base, String cn, String gidNumber, Boolean groupOfNames)
 			throws NamingException {
 
 		Attributes attrs;
 
 		if (! groupOfNames) {
-			if (ldapGroupObjectclasses == null || ldapGroupObjectclasses.trim().isEmpty())
+			if (ldapGroupObjectclasses == null || ldapGroupObjectclasses.isBlank())
 				ldapGroupObjectclasses = "top posixGroup";
-			
+
 			if (sambaEnabled && (! ldapGroupObjectclasses.matches("(?:\\s|.)*?\\bsambaGroupMapping\\b(?:\\s|.)*"))) {
 				ldapGroupObjectclasses += " sambaGroupMapping";
 			}
-	
+
 			attrs = AttributesFactory.createAttributes("objectClass",
 	                ldapGroupObjectclasses.split("\\s+"));
-	
+
 			if (sambaEnabled) {
-				attrs.put(AttributesFactory.createAttribute("sambaSID", sidPrefix + (Long.parseLong(gidNumber) * 2L + 1000L)));					
+				attrs.put(AttributesFactory.createAttribute("sambaSID", sidPrefix + (Long.parseLong(gidNumber) * 2L + 1000L)));
 				attrs.put(AttributesFactory.createAttribute("sambaGroupType", "2"));
 			}
-	
+
 			attrs.put(AttributesFactory.createAttribute("cn", cn));
 			attrs.put(AttributesFactory.createAttribute("gidNumber", gidNumber));
-	
+
 			ldap.create("cn=" + cn + "," + base, attrs);
 		}
 		else {
 			/*
 			 * grouptype is member, create groups with groupOfNames Schema
 			 */
-			if (ldapGroupType != null && ldapGroupMemberBase != null 
+			if (ldapGroupType != null && ldapGroupMemberBase != null
 					&& ldapGroupType.equals("member")) {
 				attrs = AttributesFactory.createAttributes("objectClass", new String[] {"top", "groupOfNames", "gidNumberGroup"});
 				attrs.put(AttributesFactory.createAttribute("cn", cn));

--- a/bwreg-webapp/src/main/java/edu/kit/scc/webreg/bean/DiscoveryLoginBean.java
+++ b/bwreg-webapp/src/main/java/edu/kit/scc/webreg/bean/DiscoveryLoginBean.java
@@ -45,6 +45,7 @@ import edu.kit.scc.webreg.service.oidc.OidcClientConfigurationService;
 import edu.kit.scc.webreg.service.oidc.OidcOpConfigurationService;
 import edu.kit.scc.webreg.service.oidc.OidcRpConfigurationService;
 import edu.kit.scc.webreg.service.oidc.ServiceOidcClientService;
+import edu.kit.scc.webreg.service.oidc.client.OidcDiscoverySingletonBean;
 import edu.kit.scc.webreg.service.saml.FederationSingletonBean;
 import edu.kit.scc.webreg.session.SessionManager;
 import edu.kit.scc.webreg.util.CookieHelper;
@@ -67,6 +68,9 @@ public class DiscoveryLoginBean implements Serializable {
 	
 	@Inject
 	private OidcRpConfigurationService oidcRpService;
+	
+	@Inject
+	private OidcDiscoverySingletonBean oidcDiscoverySingletonBean;
 	
 	@Inject
 	private SessionManager sessionManager;
@@ -276,6 +280,10 @@ public class DiscoveryLoginBean implements Serializable {
 				for (ServiceOidcClientEntity serviceOidcClient : serviceOidcClientList) {
 					if (serviceOidcClient.getScript() != null) {
 						idpList.addAll(federationBean.getFilteredIdpList(serviceOidcClient.getScript()));
+
+						if (appConfig.getConfigValueOrDefault("show_oidc_login", "false").equalsIgnoreCase("true")) {
+							idpList.addAll(oidcDiscoverySingletonBean.getFilteredOpList(serviceOidcClient.getScript()));
+						}			
 					}
 				}
 			}
@@ -292,6 +300,10 @@ public class DiscoveryLoginBean implements Serializable {
 				for (ServiceSamlSpEntity serviceSaml : serviceSamlList) {
 					if (serviceSaml.getScript() != null) {
 						idpList.addAll(federationBean.getFilteredIdpList(serviceSaml.getScript()));
+
+						if (appConfig.getConfigValueOrDefault("show_oidc_login", "false").equalsIgnoreCase("true")) {
+							idpList.addAll(oidcDiscoverySingletonBean.getFilteredOpList(serviceSaml.getScript()));
+						}			
 					}
 				}
 			}
@@ -301,11 +313,12 @@ public class DiscoveryLoginBean implements Serializable {
 				 */
 				getIdpList().clear();
 				getIdpList().addAll(federationBean.getAllIdpList());
+
+				if (appConfig.getConfigValueOrDefault("show_oidc_login", "false").equalsIgnoreCase("true")) {
+					idpList.addAll(oidcRpService.findAll());
+				}			
 			}
 
-			if (appConfig.getConfigValueOrDefault("show_oidc_login", "false").equalsIgnoreCase("true")) {
-				idpList.addAll(oidcRpService.findAll());
-			}			
 		}
 		else {
 			if (selectedFederation instanceof FederationEntity) {

--- a/bwreg-webapp/src/main/java/edu/kit/scc/webreg/bean/admin/bulk/BulkUserImportBean.java
+++ b/bwreg-webapp/src/main/java/edu/kit/scc/webreg/bean/admin/bulk/BulkUserImportBean.java
@@ -79,7 +79,7 @@ public class BulkUserImportBean implements Serializable {
 	
 	private List<ImportUser> importUserList;
 
-	private ImportUser[] selectedImport;
+	private List<ImportUser> selectedImport;
 	
 	public void fillTable() {
 		importUserList = new ArrayList<ImportUser>();
@@ -107,7 +107,7 @@ public class BulkUserImportBean implements Serializable {
 	public void processSelected() {
 		for (ImportUser importUser : selectedImport) {
 			logger.debug("Processing user {} for import: {}", importUser.getUid(), importUser.getPersistentId());
-			SamlUserEntity userEntity = userService.findByPersistentWithRoles(importUser.getSpEntityId(), 
+			SamlUserEntity userEntity = userService.findByPersistent(importUser.getSpEntityId(), 
 					importUser.getIdpEntityId(), importUser.getPersistentId());
 			
 			SamlSpConfigurationEntity spEntity = spService.findByEntityId(importUser.getSpEntityId());
@@ -188,12 +188,12 @@ public class BulkUserImportBean implements Serializable {
 		this.idpEntityId = idpEntityId;
 	}
 
-	public ImportUser[] getSelectedImport() {
+	public List<ImportUser> getSelectedImport() {
 		return selectedImport;
 	}
 
-	public void setSelectedImport(ImportUser[] selectedImport) {
+	public void setSelectedImport(List<ImportUser> selectedImport) {
 		this.selectedImport = selectedImport;
 	}
-	
+
 }

--- a/bwreg-webapp/src/main/java/edu/kit/scc/webreg/rest/SshKeyController.java
+++ b/bwreg-webapp/src/main/java/edu/kit/scc/webreg/rest/SshKeyController.java
@@ -56,6 +56,25 @@ public class SshKeyController {
 		return dtoService.findByUidNumberAndStatus(uidNumber, keyStatus);
 	}
 	
+	@Path(value = "/list/uidnumber/{uidNumber}/keys-expiring-soon/{days}")
+	@Produces({MediaType.APPLICATION_JSON})
+	@GET
+	// example: https://..../rest/ssh-key/list/uidnumber/900001/keys-expiring-soon/30	
+	public List<SshPubKeyEntityDto> listKeysForUserAndExpiryInDays(@PathParam("uidNumber") Long uidNumber,
+			@PathParam("days") Integer days, @Context HttpServletRequest request)
+					throws IOException, RestInterfaceException {
+		return dtoService.findByUidNumberAndExpiryInDays(uidNumber, days);
+	}
+	
+	@Path(value = "/list/keys-expiring-soon/{days}")
+	@Produces({MediaType.APPLICATION_JSON})
+	@GET
+	// example: https://..../rest/ssh-key/list/keys-expiring-soon/30	
+	public List<SshPubKeyEntityDto> listKeysExpiryInDays(@PathParam("days") Integer days, @Context HttpServletRequest request)
+					throws IOException, RestInterfaceException {
+		return dtoService.findByExpiryInDays(days);
+	}
+	
 	@Path(value = "/auth/all/{ssn}/uidnumber/{uidNumber}")
 	@Produces({MediaType.TEXT_PLAIN})
 	@GET

--- a/bwreg-webapp/src/main/resources/msg/messages_de.properties
+++ b/bwreg-webapp/src/main/resources/msg/messages_de.properties
@@ -1028,7 +1028,7 @@ twofa_active = Aktiv
 
 twofa_back_to_register = Zur\u00FCck zum Registriervorgang
 
-twofa_backup_tan_list_values = Hier sehen Sie die n\u00E4chsten f\u00FCnf Werte Ihrer TAN Liste. Diese Werte m\u00FCssen in der angezeigten Reihenfolge verwendet werden.
+twofa_backup_tan_list_values = Hier sehen Sie die n\u00E4chsten Werte Ihrer TAN Liste. Diese Werte m\u00FCssen in der angezeigten Reihenfolge verwendet werden.
 
 twofa_code = Aktueller code
 

--- a/bwreg-webapp/src/main/resources/msg/messages_en.properties
+++ b/bwreg-webapp/src/main/resources/msg/messages_en.properties
@@ -1028,7 +1028,7 @@ twofa_active = Active
 
 twofa_back_to_register = Back to registration
 
-twofa_backup_tan_list_values = Here you see the next five values of your TAN list. These values must be used in the displayed order.
+twofa_backup_tan_list_values = Here you see the next values of your TAN list. These values must be used in the displayed order.
 
 twofa_code = Current code
 

--- a/bwreg-webapp/src/main/resources/msg/messages_fr.properties
+++ b/bwreg-webapp/src/main/resources/msg/messages_fr.properties
@@ -1028,7 +1028,7 @@ twofa_active = Actif
 
 twofa_back_to_register = Retour \u00E0 l'enregistrement
 
-twofa_backup_tan_list_values = Vous voyez ici les cinq prochaines valeurs de votre liste TAN. Ces valeurs doivent \u00EAtre utilis\u00E9es dans l'ordre affich\u00E9.
+twofa_backup_tan_list_values = Vous voyez ici les prochaines valeurs de votre liste TAN. Ces valeurs doivent \u00EAtre utilis\u00E9es dans l'ordre affich\u00E9.
 
 twofa_code = Code actuel
 


### PR DESCRIPTION
In diesem PR wird eine alternative Art eingeführt, LDAP-Accounts zu "löschen".

Dazu werden im LdapWorker drei Attribute berücksichtigt:

- **ldap\_activation\_attribute\_name**: LDAP Attributsname, mit dem festgehalten wird, ob ein LDAP-Account aktiv oder "gelöscht" ist (benötigt, sonst wird wie zuvor der LDAP-Eintrag komplett gelöscht)
- **ldap_activation_attribute_positive_value**: der Wert, der im LDAP einen aktiven Account repräsentiert (optional, Standardwert: "active")
- **ldap_activation_attribute_negative_value**: der Wert, der im LDAP einen deaktivierten Account repräsentiert (optional, Standardwert: "deactivated")
