### PR TITLE
Add DeleteOutOfDateUsers job class bean

### DIFF
--- a/bwreg-jpa/src/main/java/edu/kit/scc/webreg/dao/UserDao.java
+++ b/bwreg-jpa/src/main/java/edu/kit/scc/webreg/dao/UserDao.java
@@ -10,13 +10,12 @@
  ******************************************************************************/
 package edu.kit.scc.webreg.dao;
 
-import java.util.Date;
-import java.util.List;
-
 import edu.kit.scc.webreg.entity.GroupEntity;
 import edu.kit.scc.webreg.entity.UserEntity;
 import edu.kit.scc.webreg.entity.UserStatus;
 import edu.kit.scc.webreg.entity.identity.IdentityEntity;
+import java.util.Date;
+import java.util.List;
 
 public interface UserDao extends BaseDao<UserEntity> {
 
@@ -30,6 +29,7 @@ public interface UserDao extends BaseDao<UserEntity> {
 	List<UserEntity> findGenericStoreKeyWithLimit(String key, Integer limit);
 	List<UserEntity> findOrderByFailedUpdateWithLimit(Date date, Integer limit);
 	List<UserEntity> findByStatus(UserStatus status);
+	List<UserEntity> findByStatusAndTimeSince(UserStatus status, Long statusSince, Integer limit);
 	UserEntity findByUidNumber(Long uidNumber);
 	List<UserEntity> findMissingIdentity();
 	List<UserEntity> findByIdentity(IdentityEntity identity);

--- a/bwreg-service/src/main/java/edu/kit/scc/webreg/job/AbstractDeleteUserData.java
+++ b/bwreg-service/src/main/java/edu/kit/scc/webreg/job/AbstractDeleteUserData.java
@@ -1,0 +1,94 @@
+package edu.kit.scc.webreg.job;
+
+import edu.kit.scc.webreg.entity.SamlUserEntity;
+import edu.kit.scc.webreg.entity.UserEntity;
+import edu.kit.scc.webreg.entity.UserStatus;
+import edu.kit.scc.webreg.entity.identity.IdentityEntity;
+import edu.kit.scc.webreg.exc.RegisterException;
+import edu.kit.scc.webreg.exc.UserUpdateException;
+import edu.kit.scc.webreg.service.UserDeleteService;
+import edu.kit.scc.webreg.service.UserService;
+import java.util.List;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Abstract class for deleting non-active users.
+ *
+ * @author Michael Burgardt
+ */
+public abstract class AbstractDeleteUserData extends AbstractExecutableJob {
+
+    public static Logger logger = LoggerFactory.getLogger(AbstractDeleteUserData.class);
+
+    /**
+     * Attempts to delete all user data for users with given status.
+     *
+     * @param targetStatus Process users with this status only.
+     * @param lastUpdate [ms] If a user has targetStatus for longer
+     * than this, their user data is deleted. Set to -1 to prevent any and all
+     * deletions.
+     * @param lastUserUpdate [ms] If a user was last updated longer than this ago,
+     * attempt to update them before performing the deletion.
+     * @param limit This value determines how many registries are processed at
+     * once.
+     */
+    public void executeDeletion (UserStatus targetStatus, Long lastUpdate, Long lastUserUpdate, Integer limit) {
+        String auditName = targetStatus + "-rem-job";
+
+        try {
+            InitialContext ic = new InitialContext();
+            UserService userService = (UserService) ic.lookup("global/bwreg/bwreg-service/UserServiceImpl!edu.kit.scc.webreg.service.UserService");
+            UserDeleteService userDeleteService = (UserDeleteService) ic.lookup("global/bwreg/bwreg-service/UserDeleteServiceImpl!edu.kit.scc.webreg.service.UserDeleteService");
+
+            List<UserEntity> userList;
+            logger.info("Initialising deletion of {} users", targetStatus);
+            userList = userService.findByStatusAndTimeSince(targetStatus, lastUpdate, limit);
+
+            for (UserEntity user : userList) {
+                try {
+                    logger.debug("Attempting to delete user {}", user.getEppn());
+
+                    if (user instanceof SamlUserEntity) {
+                        SamlUserEntity samlUser = (SamlUserEntity) user;
+                        IdentityEntity identity = samlUser.getIdentity();
+
+                        Long sinceLastChange = System.currentTimeMillis() - samlUser.getLastStatusChange().getTime();
+                        Long sinceLastUpdate = System.currentTimeMillis() - samlUser.getLastUpdate().getTime();
+                        if (sinceLastUpdate > lastUserUpdate) {
+                            logger.info("User {} lastUpdate is older than {}ms, trying to update", user.getEppn(), lastUserUpdate);
+                            try {
+                                userService.updateUserFromIdp(samlUser, auditName);
+                                logger.info("Update performed");
+                            } catch (UserUpdateException e) {
+                                logger.info("Exception while querying IDP: {}\nUpdate fails since {}ms ago", e.getMessage(), sinceLastUpdate);
+                                if (e.getCause() != null) {
+                                    logger.info("Cause is: {}", e.getCause().getMessage());
+                                    if (e.getCause().getCause() != null) {
+                                        logger.info("Inner cause is: {}", e.getCause().getCause().getMessage());
+                                    }
+                                }
+                                // resume without deregistering user
+                                throw new RegisterException("IDP failed");
+                            }
+                        }
+
+                        if (targetStatus.equals(samlUser.getUserStatus())) {
+                            logger.info("User {} had status {} for {}ms, attempting deletion", samlUser.getEppn(), targetStatus, sinceLastChange);
+                            userDeleteService.deleteUserData(identity, "identity-" + identity.getId());
+                            logger.info("Deletion successful");
+                        } else {
+                            logger.info("User status changed. User deletion postponed for another {}ms", lastUpdate - sinceLastChange);
+                        }
+                    }
+                } catch (RegisterException e) {
+                    logger.info("Due update failed, postponing deletion", e);
+                }
+            }
+        } catch (NamingException e) {
+            logger.warn("Could not delete users: {}", e);
+        }
+    }
+}

--- a/bwreg-service/src/main/java/edu/kit/scc/webreg/job/DeleteOutOfDateUsers.java
+++ b/bwreg-service/src/main/java/edu/kit/scc/webreg/job/DeleteOutOfDateUsers.java
@@ -1,0 +1,70 @@
+package edu.kit.scc.webreg.job;
+
+import edu.kit.scc.webreg.entity.UserStatus;
+import javax.inject.Inject;
+import org.slf4j.Logger;
+
+/**
+ * Job class for deleting users.
+ *
+ * Required Parameters:
+ *
+ * target_status_since_millis: Users which remain in specified status for
+ * this long (in milliseconds) are deleted.
+ *
+ * target_user_status: Only users with this status will be deleted. Possible
+ * values: blocked, deregistered, on_hold.
+ *
+ * Optional Parameters:
+ *
+ * registries_per_exec: This value determines how many users are processed
+ * at once. This can reduce load on the database and prevents too long running
+ * database transaction, if a low value is chosen. Ie. only 1 registry (default
+ * value), but every minute.
+ *
+ * last_user_update_millis: If the last user update is older than this value in
+ * milliseconds (default: 14 day = 1209600000), an update is attempted. The
+ * user is only deleted, if their status doesn't change.
+ *
+ * @author Michael Burgardt
+ */
+public class DeleteOutOfDateUsers extends AbstractDeleteUserData {
+    @Inject
+    private Logger logger;
+    @Override
+    public void execute() {
+
+        if (!getJobStore().containsKey("target_status_since_millis")) {
+            logger.warn("DeleteOutOfDateUsers is not configured correctly. max_acceptable_period_millis parameter is missing in JobMap");
+            return;
+        }
+        Long maxAbsencePeriod = Long.parseLong(getJobStore().get("target_status_since_millis"));
+
+        Long updateAfter = 14 * 24 * 60 * 60 * 1000L; // 14 day
+        if (getJobStore().containsKey("last_user_update_millis")) {
+            updateAfter = Long.parseLong(getJobStore().get("last_user_update_millis"));
+        }
+
+        Integer limit = 1;
+        if (getJobStore().containsKey("registries_per_exec")) {
+            limit = Integer.parseInt(getJobStore().get("registries_per_exec"));
+        }
+
+        switch (String.valueOf(getJobStore().getOrDefault("target_user_status", ""))) {
+            case "BLOCKED":
+            case "blocked":
+                executeDeletion(UserStatus.BLOCKED, maxAbsencePeriod, updateAfter, limit);
+                break;
+            case "DEREGISTERED":
+            case "deregistered":
+                executeDeletion(UserStatus.DEREGISTERED, maxAbsencePeriod, updateAfter, limit);
+                break;
+            case "ON_HOLD":
+            case "on_hold":
+                executeDeletion(UserStatus.ON_HOLD, maxAbsencePeriod, updateAfter, limit);
+                break;
+            default:
+                logger.warn("UpdateOrDeleteUserDataJob is not configured correctly. target_user_status parameter in JobMap must be one of: blocked, deregistered or on_hold");
+        }
+    }
+}

--- a/bwreg-service/src/main/java/edu/kit/scc/webreg/service/UserService.java
+++ b/bwreg-service/src/main/java/edu/kit/scc/webreg/service/UserService.java
@@ -10,11 +10,6 @@
  ******************************************************************************/
 package edu.kit.scc.webreg.service;
 
-import java.util.Date;
-import java.util.List;
-
-import org.opensaml.saml.saml2.core.Assertion;
-
 import edu.kit.scc.webreg.entity.GroupEntity;
 import edu.kit.scc.webreg.entity.SamlUserEntity;
 import edu.kit.scc.webreg.entity.ServiceEntity;
@@ -25,6 +20,9 @@ import edu.kit.scc.webreg.entity.UserLoginMethod;
 import edu.kit.scc.webreg.entity.UserStatus;
 import edu.kit.scc.webreg.entity.identity.IdentityEntity;
 import edu.kit.scc.webreg.exc.UserUpdateException;
+import java.util.Date;
+import java.util.List;
+import org.opensaml.saml.saml2.core.Assertion;
 
 public interface UserService extends BaseService<UserEntity> {
 
@@ -48,6 +46,8 @@ public interface UserService extends BaseService<UserEntity> {
 			throws UserUpdateException;
 
 	List<UserEntity> findByStatus(UserStatus status);
+
+	List<UserEntity> findByStatusAndTimeSince(UserStatus status, Long statusSince, Integer limit);
 
 	void checkOnHoldRegistries(UserEntity user);
 

--- a/bwreg-service/src/main/java/edu/kit/scc/webreg/service/impl/UserServiceImpl.java
+++ b/bwreg-service/src/main/java/edu/kit/scc/webreg/service/impl/UserServiceImpl.java
@@ -10,16 +10,6 @@
  ******************************************************************************/
 package edu.kit.scc.webreg.service.impl;
 
-import java.io.Serializable;
-import java.util.Date;
-import java.util.List;
-
-import javax.ejb.Stateless;
-import javax.inject.Inject;
-
-import org.opensaml.saml.saml2.core.Assertion;
-import org.slf4j.Logger;
-
 import edu.kit.scc.webreg.dao.BaseDao;
 import edu.kit.scc.webreg.dao.RegistryDao;
 import edu.kit.scc.webreg.dao.SamlUserDao;
@@ -39,6 +29,13 @@ import edu.kit.scc.webreg.entity.UserStatus;
 import edu.kit.scc.webreg.entity.identity.IdentityEntity;
 import edu.kit.scc.webreg.exc.UserUpdateException;
 import edu.kit.scc.webreg.service.UserService;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.List;
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.slf4j.Logger;
 
 @Stateless
 public class UserServiceImpl extends BaseServiceImpl<UserEntity> implements UserService, Serializable {
@@ -137,7 +134,12 @@ public class UserServiceImpl extends BaseServiceImpl<UserEntity> implements User
 	public List<UserEntity> findByStatus(UserStatus status) {
 		return dao.findByStatus(status);
 	}
-	
+
+	@Override
+	public List<UserEntity> findByStatusAndTimeSince(UserStatus status, Long statusSince, Integer limit) {
+		return dao.findByStatusAndTimeSince(status, statusSince, limit);
+	}
+
 	@Override
 	public UserEntity findByIdWithAll(Long id) {
 		return dao.findByIdWithAll(id);


### PR DESCRIPTION
Wie im heutigen Meeting besprochen, hier die (überarbeitete) Job-Klasse zum löschen von Usern.
Ich habe eine neue findByStatusAndTimeSince methode für den UserService implementiert, um nur eine begrenzte Menge tatsächlich auch in Frage kommender Kandidaten zusammensuchen zu können.
Könnte eventuell etwas zu flexibel sein, aber das lässt sich ja leicht ändern.