### PR TITLE
Feature/deregister and fixes

### DIFF
--- a/bwreg-service/src/main/java/edu/kit/scc/webreg/service/impl/UserUpdateFromHomeOrgServiceImpl.java
+++ b/bwreg-service/src/main/java/edu/kit/scc/webreg/service/impl/UserUpdateFromHomeOrgServiceImpl.java
@@ -17,6 +17,8 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 
 import edu.kit.scc.webreg.dao.UserDao;
+import edu.kit.scc.webreg.dao.ops.NullOrder;
+import edu.kit.scc.webreg.dao.ops.SortBy;
 import edu.kit.scc.webreg.entity.SamlUserEntity;
 import edu.kit.scc.webreg.entity.UserEntity;
 import edu.kit.scc.webreg.entity.UserEntity_;
@@ -67,7 +69,8 @@ public class UserUpdateFromHomeOrgServiceImpl implements UserUpdateFromHomeOrgSe
 	@Override
 	public List<UserEntity> findScheduledUsers(Integer limit) {
 		Date now = new Date();
-		return userDao.findAll(withLimit(limit), and(notEqual(UserEntity_.userStatus, UserStatus.DEREGISTERED),
+		return userDao.findAll(withLimit(limit), SortBy.ascendingBy(UserEntity_.scheduledUpdate, NullOrder.NULL_FIRST),
+				and(notEqual(UserEntity_.userStatus, UserStatus.DEREGISTERED),
 				or(lessThan(UserEntity_.scheduledUpdate, now), isNull(UserEntity_.scheduledUpdate))));
 	}
 

--- a/bwreg-webapp/src/main/java/edu/kit/scc/webreg/rest/ServiceAdminController.java
+++ b/bwreg-webapp/src/main/java/edu/kit/scc/webreg/rest/ServiceAdminController.java
@@ -174,6 +174,32 @@ public class ServiceAdminController {
 			throw e;
 		}
 	}
+        
+	@Path(value = "/deregister/{ssn}/by-id/{regId}")
+	@Produces({ "text/plain" })
+	@GET
+	public Response deregister(@PathParam("ssn") String ssn, @PathParam("regId") Long regId,
+			@Context HttpServletRequest request) throws RestInterfaceException, RegisterException {
+
+		ServiceEntity serviceEntity = serviceService.findByShortName(ssn);
+		if (serviceEntity == null)
+			throw new NoItemFoundException("No such service");
+
+		if (!checkAccess(request, serviceEntity.getAdminRole().getName()))
+			throw new UnauthorizedException("No access");
+
+		RegistryEntity registryEntity = registryService.fetch(regId);
+		if (registryEntity == null)
+			throw new NoItemFoundException("No such registry");
+
+		try {
+			registerUserService.deregisterUser(registryEntity, resolveUsername(request), "deregister-via-api");
+			return Response.ok("registry deregistered", MediaType.TEXT_PLAIN_TYPE).build();
+		} catch (RegisterException e) {
+			logger.warn("Deregister failed!", e);
+			throw e;
+		}
+	}
 
 	@Path(value = "/recon/all/{ssn}")
 	@Produces({ "text/plain" })

--- a/regapp-jpa-impl/src/main/java/edu/kit/scc/webreg/dao/jpa/JpaBaseDao.java
+++ b/regapp-jpa-impl/src/main/java/edu/kit/scc/webreg/dao/jpa/JpaBaseDao.java
@@ -294,7 +294,8 @@ public abstract class JpaBaseDao<T extends BaseEntity> implements BaseDao<T> {
 		} else if (Long.class.equals(javaTypeOfField)) {
 			replacement = replaceWithMaxValue ? Long.MAX_VALUE : Long.MIN_VALUE;
 		} else if (Date.class.equals(javaTypeOfField)) {
-			replacement = replaceWithMaxValue ? new Date(Long.MAX_VALUE) : new Date(Long.MIN_VALUE);
+			replacement = replaceWithMaxValue ? new Date(9224318015999999L) // 294276-12-31 23:59:59.999
+					: new Date(-210866803200000L); // -4713-01-01 00:00:00
 		} else if (String.class.equals(javaTypeOfField)) {
 			if (replaceWithMaxValue) {
 				throw new UnsupportedOperationException(String.format("Combination of %s with %s is not supported for String typed fields",

--- a/regapp-jpa-impl/src/main/java/edu/kit/scc/webreg/dao/jpa/JpaRoleDao.java
+++ b/regapp-jpa-impl/src/main/java/edu/kit/scc/webreg/dao/jpa/JpaRoleDao.java
@@ -169,7 +169,7 @@ public class JpaRoleDao extends JpaBaseDao<RoleEntity> implements RoleDao {
 	@Override
 	public Boolean checkAdminUserInRole(Long userId, String roleName) {
 		List<RoleEntity> roleList = em
-				.createQuery("select u.roles from AdminUserEntity u where u.id = :userId", RoleEntity.class)
+				.createQuery("select u.roles from AdminUserEntity u where u.id = :userId")
 				.setParameter("userId", userId).getResultList();
 		return roleList.size() > 0 && em
 				.createQuery("select r from RoleEntity r where r.name = :roleName and r in :roleList", RoleEntity.class)


### PR DESCRIPTION
Von mir dürften nur die letzten 4 Commits sein.
Wenn du dein Repo vorher aktualisierst, dürfte es übersichtlicher sein.
Wenn ich stattdessen besser auf deinem Github-, statt Gitlab-Stand arbeiten soll, einfach Bescheid geben.
Ebenso wenn ich Änderungen thematisch in mehrere branches aufteilen soll, um so besser nachträglich Änderungen an bestimmten Dingen machen zu können.

Beim Commit f4649b32de7a5871138fe9a7457369a0f0fe63b8 scheint die Angabe der RoleEntity.class Probleme zu machen. Vermutlich da das roles-Attribut in der AdminUserEntity-Klasse ein Set ist. Ich habe versucht die Set-Klasse anzugeben, mich mit generics rumgeschlagen, und versucht am Ende wieder alles in eine Liste zu packen, um dann zur zweiten Query überzugehen.
Leider hat nichts so wirklich funktioniert. Und es scheint, dass es gar keine Sets sind, die von der ersten Query zurückgeliefert werden, obwohl die Query selber nur mit Set als class funktioniert.
Jedenfalls war meine Lösung dann, die Angabe der Klasse an dieser einen Stelle komplett zu entfernen, wie es vor dem Refactoring auch war.