### PR TITLE
Bugfix/automatic projects

### DIFF
--- a/regapp-project/src/main/java/edu/kit/scc/webreg/service/project/AbstractProjectUpdater.java
+++ b/regapp-project/src/main/java/edu/kit/scc/webreg/service/project/AbstractProjectUpdater.java
@@ -276,9 +276,11 @@ public abstract class AbstractProjectUpdater<T extends ProjectEntity> implements
 
 		triggerGroupUpdate(project, executor);
 
-		for (ProjectEntity childProject : project.getChildProjects()) {
-			updateServices(childProject, serviceList, type, status, executor, depth + 1, maxDepth);
-		}
+		if (project.getChildProjects() != null) {
+                        for (ProjectEntity childProject : project.getChildProjects()) {
+                                updateServices(childProject, serviceList, type, status, executor, depth + 1, maxDepth);
+                        }
+                }
 	}
 
 	private void syncGroupFlags(ProjectServiceEntity pse, String executor) {

--- a/regapp-project/src/main/java/edu/kit/scc/webreg/service/project/AttributeSourceProjectUpdater.java
+++ b/regapp-project/src/main/java/edu/kit/scc/webreg/service/project/AttributeSourceProjectUpdater.java
@@ -52,7 +52,7 @@ public class AttributeSourceProjectUpdater extends AbstractProjectUpdater<Attrib
 								.equals(attributeSource)))
 				.collect(Collectors.toList());
 
-		logger.debug("Identity {} is admin in {} projects and {} in attribute sourced proects", identity.getId(),
+		logger.debug("Identity {} is admin in {} projects and in {} attribute sourced projects", identity.getId(),
 				adminList.size(), filteredAdminList.size());
 
 		for (ProjectIdentityAdminEntity pia : filteredAdminList) {

--- a/regapp-project/src/main/java/edu/kit/scc/webreg/service/project/AttributeSourceProjectUpdater.java
+++ b/regapp-project/src/main/java/edu/kit/scc/webreg/service/project/AttributeSourceProjectUpdater.java
@@ -81,7 +81,7 @@ public class AttributeSourceProjectUpdater extends AbstractProjectUpdater<Attrib
 
 			logger.debug("Checking if service connections are correct for {}", project.getName());
 			Set<ServiceEntity> serviceList = attributeSource.getAttributeSourceServices().stream().map(asse -> asse.getService()).collect(Collectors.toSet());
-			projectUpdater.updateServices(project, serviceList, ProjectServiceType.PASSIVE_GROUP,ProjectServiceStatusType.ACTIVE, "attribute-srouce-" + attributeSource.getId());
+			projectUpdater.updateServices(project, serviceList, ProjectServiceType.PASSIVE_GROUP,ProjectServiceStatusType.ACTIVE, "attribute-source-" + attributeSource.getId());
 			
 			// Add missing connections to service
 //			for (AttributeSourceServiceEntity asse : attributeSource.getAttributeSourceServices()) {
@@ -89,7 +89,7 @@ public class AttributeSourceProjectUpdater extends AbstractProjectUpdater<Attrib
 //						.noneMatch(ps -> ps.getService().equals(asse.getService()))) {
 //					logger.debug("Connecting project {} with service {}", project.getName(), asse.getService().getName());
 //					projectUpdater.addOrChangeService(project, asse.getService(), ProjectServiceType.PASSIVE_GROUP,
-//							ProjectServiceStatusType.ACTIVE, "attribute-srouce-" + attributeSource.getId());
+//							ProjectServiceStatusType.ACTIVE, "attribute-source-" + attributeSource.getId());
 //				}
 //			}
 //


### PR DESCRIPTION
Zum einen hatten wir beim Anlegen ein Problem mit null Objecten und childProjects. Keine Ahnung warum das scheinbar nur bei uns Probleme gemacht hat.

Zum anderen konnten wir über die Attribute Source die Projektzuordnungen nicht mehr entfernen. Ursache war hier, dass unsere JARDS Schnittstelle einen pi_key ohne Werte geliefert hat, statt den Key erst gar nicht mit zu liefern, wenn eine Person kein Projekt mehr besaß. Wodurch die RegApp versucht hat, Projekt und Gruppe mit leerem Namen anzulegen.
Hier müsstest du abschätzen, ob das generelle Rausfiltern von leeren Attribute Source Werten Probleme für bestehende Prozesse macht, und damit nicht mehr abwärtskompatibel ist. Meine nächste Idee wäre das nur bei Projekten rauszufiltern, aber für Gruppen bräuchte man dann wohl genau das gleiche.